### PR TITLE
v0.1.2 Contribution

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,0 +1,17 @@
+v0.1.2
+
+Patch notes:
+Changed accuracy threshold for fireworks from a fixed angle to a multiple of the target radius.
+Added a setting for engine ignition delay time to missiles.
+Added a setting to toggle the automatic playing of animations on scanners.
+Ships will no longer move away from their target when below minimum range if their current weapon is a projectile.
+Ships will now ignore target intercept adjustments of less than a second.
+Renamed some settings for clarity.
+RCS with throttle enabled now counts towards ship propulsion status.
+
+Code Changes:
+Hid unused settings.
+Simplified FindCommand.
+Fixed bugs in the rocket module.
+Fixed a ship movement bug caused by max weapon range exceeding lock range.
+Fixed object tracking info panels in part menu displaying 0.

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,17 +1,19 @@
 v0.1.2
 
 Patch notes:
-Changed accuracy threshold for fireworks from a fixed angle to a multiple of the target radius.
-Added a setting for engine ignition delay time to missiles.
-Added a setting to toggle the automatic playing of animations on scanners.
-Ships will no longer move away from their target when below minimum range if their current weapon is a projectile.
-Ships will now ignore target intercept adjustments of less than a second.
-Renamed some settings for clarity.
-RCS with throttle enabled now counts towards ship propulsion status.
 
-Code Changes:
-Hid unused settings.
-Simplified FindCommand.
-Fixed bugs in the rocket module.
-Fixed a ship movement bug caused by max weapon range exceeding lock range.
-Fixed object tracking info panels in part menu displaying 0.
+- Added automatic support for horizontal missile launches via RCS.
+- Added a setting for engine ignition delay time to missiles.
+- Added a setting to toggle the automatic playing of animations on scanners.
+
+- Changed accuracy threshold for fireworks from a fixed angle to a multiple of the target radius.
+- Ships will no longer move away from their target when below minimum range if their current weapon is a projectile.
+- Ships will now ignore target intercept adjustments of less than a second.
+- RCS with throttle enabled now counts towards ship propulsion status.
+- Renamed some settings for clarity.
+- Hid unused settings.
+- Changed the style of the ship labels in the overlay.
+
+- Fixed a bug causing missile stacks to fire in the wrong order.
+- Fixed object tracking info panels in part menu displaying 0.
+- Fixed a ship movement bug caused by max weapon range exceeding lock range.

--- a/GameData/KCS/Changelog.txt
+++ b/GameData/KCS/Changelog.txt
@@ -3,8 +3,9 @@ v0.1.2
 Patch notes:
 
 - Added automatic support for horizontal missile launches via RCS.
+- Added a target prioritisation setting based on a mass range, only applies to targets within 2x max weapons range.
 - Added a setting to toggle the automatic playing of animations on scanners.
-- Added a 'Firing Interval' setting to the ship controller for controlling the time between missile salvos.
+- Added a 'Salvo Interval' setting to the ship controller for controlling the time between missile salvos.
 - Added a setting to the ship controller to toggle evasion.
 - Added a 'Forward Fire Throttle Limit' setting to the ship controller to limit the throttle while missiles are launching from the front of the ship. Zero by default.
 - Added a setting for time between firework bursts.

--- a/GameData/KCS/Changelog.txt
+++ b/GameData/KCS/Changelog.txt
@@ -3,8 +3,15 @@ v0.1.2
 Patch notes:
 
 - Added automatic support for horizontal missile launches via RCS.
-- Added a setting for engine ignition delay time to missiles.
 - Added a setting to toggle the automatic playing of animations on scanners.
+- Added a 'Firing Interval' setting to the ship controller for controlling the time between missile salvos.
+- Added a setting to the ship controller to toggle evasion.
+- Added a 'Forward Fire Throttle Limit' setting to the ship controller to limit the throttle while missiles are launching from the front of the ship. Zero by default.
+- Added missile settings:
+	- Launch delay.
+	- Launch duration.
+	- Launch throttle.
+	- Salvo spacing.
 
 - Changed accuracy threshold for fireworks from a fixed angle to a multiple of the target radius.
 - Ships will no longer move away from their target when below minimum range if their current weapon is a projectile.

--- a/GameData/KCS/Changelog.txt
+++ b/GameData/KCS/Changelog.txt
@@ -9,6 +9,7 @@ Patch notes:
 - Changed accuracy threshold for fireworks from a fixed angle to a multiple of the target radius.
 - Ships will no longer move away from their target when below minimum range if their current weapon is a projectile.
 - Ships will now ignore target intercept adjustments of less than a second.
+- Ships now decide whether to withdraw north or south based on the position of enemy ships.  
 - RCS with throttle enabled now counts towards ship propulsion status.
 - Renamed some settings for clarity.
 - Hid unused settings.

--- a/GameData/KCS/Changelog.txt
+++ b/GameData/KCS/Changelog.txt
@@ -7,6 +7,7 @@ Patch notes:
 - Added a 'Firing Interval' setting to the ship controller for controlling the time between missile salvos.
 - Added a setting to the ship controller to toggle evasion.
 - Added a 'Forward Fire Throttle Limit' setting to the ship controller to limit the throttle while missiles are launching from the front of the ship. Zero by default.
+- Added a setting for time between firework bursts.
 - Added missile settings:
 	- Launch delay.
 	- Launch duration.

--- a/GameData/KCS/Changelog.txt
+++ b/GameData/KCS/Changelog.txt
@@ -26,3 +26,4 @@ Patch notes:
 - Fixed a bug causing missile stacks to fire in the wrong order.
 - Fixed object tracking info panels in part menu displaying 0.
 - Fixed a ship movement bug caused by max weapon range exceeding lock range.
+- Fixed a bug that was preventing the use of throttle hotkeys after turning off the AI.

--- a/Source/KerbalCombatSystems/Debug.cs
+++ b/Source/KerbalCombatSystems/Debug.cs
@@ -149,7 +149,13 @@ namespace KerbalCombatSystems
                 if (missile == null || missile.vessel == null)
                     continue;
 
-                VesselLabel("ETA: " + missile.timeToHit.ToString("0.00"), missile.vessel);
+                VesselLabel("ETA: " 
+                    + missile.timeToHit.ToString("0.00")
+                    + "\n Launched: "
+                    + missile.launched.ToString()
+                    + "\n Missed: "
+                    + missile.missed.ToString(),
+                    missile.vessel);
             }
 
             foreach (ModuleShipController ship in KCSController.ships)
@@ -163,8 +169,8 @@ namespace KerbalCombatSystems
                     + ship.nearInterceptBurnTime.ToString("0.00")
                     + "\n Intercept Time: "
                     + ship.nearInterceptApproachTime.ToString("0.00")
-                    + "\n Lateral Vel: "
-                    + ship.lateralVelocity.ToString("0.00"),
+                    + "\n Throttle: "
+                    + ship.fc.throttleLerped.ToString("0.00"),
                     ship.vessel);
             }
         }

--- a/Source/KerbalCombatSystems/FireworkTargeting.cs
+++ b/Source/KerbalCombatSystems/FireworkTargeting.cs
@@ -8,6 +8,8 @@ namespace KerbalCombatSystems
 {
     public class ModuleFirework : ModuleWeapon
     {
+        public static float fireworkSpeed = 100f;
+
         // Firework Targetting variables.
         public bool firing = false;
         Vessel Target;
@@ -22,6 +24,7 @@ namespace KerbalCombatSystems
         // stored settings
         private int RoundBurst;
         private float BurstSpacing;
+        float accuracyTolerance;
 
         //list of valid launcher modules with ammo
         private List<ModulePartFirework> FireworkLaunchers;
@@ -61,7 +64,7 @@ namespace KerbalCombatSystems
                 FiringPart = firstLauncher.part;
                 controller.aimPart = FiringPart;
                 aimVector = FiringPart.transform.up;
-                LeadVector = TargetLead(Target, FiringPart, 100f).normalized;
+                LeadVector = TargetLead(Target, FiringPart, fireworkSpeed).normalized;
 
                 // Update debug lines.
                 Origin = FiringPart.transform.position;
@@ -69,7 +72,7 @@ namespace KerbalCombatSystems
             }
 
             //once aligned correctly start the firing sequence
-            if (!firing && ((Vector3.Angle(aimVector, LeadVector) < 1f) || Target == null))
+            if (!firing && OnTarget(LeadVector, aimVector, Target.CoM - FiringPart.transform.position, controller.targetSize, accuracyTolerance))
             {
                 Fire();
             }
@@ -102,7 +105,7 @@ namespace KerbalCombatSystems
                 // Change firework settings.
                 Launcher.variationOnShellDirection = false;
                 float oldVel = Launcher.shellVelocity;
-                Launcher.shellVelocity = 100f;
+                Launcher.shellVelocity = fireworkSpeed;
 
                 // Launch shell.
                 Launcher.LaunchShell();
@@ -149,12 +152,13 @@ namespace KerbalCombatSystems
             KCSDebug.DestroyLine(AimLine);
         }
 
-        public void UpdateSettings()
+        public override void UpdateSettings()
         {
             controller = part.FindModuleImplementing<ModuleWeaponController>();
             Target = controller.target;
             RoundBurst = (int)controller.FWRoundBurst;
             BurstSpacing = controller.FWBurstSpacing;
+            accuracyTolerance = controller.accuracyTolerance;
         }
     }
 }

--- a/Source/KerbalCombatSystems/FireworkTargeting.cs
+++ b/Source/KerbalCombatSystems/FireworkTargeting.cs
@@ -12,22 +12,23 @@ namespace KerbalCombatSystems
 
         // Firework Targetting variables.
         public bool firing = false;
-        Vessel Target;
-        public Vector3 LeadVector;
-        Part FiringPart;
+        Vessel target;
+        public Vector3 leadVector;
+        Part firingPart;
         Vector3 aimVector;
-        Vector3 Origin;
+        Vector3 origin;
 
         // Debugging line variables.
-        LineRenderer AimLine;
+        LineRenderer aimLine;
 
         // stored settings
-        private int RoundBurst;
-        private float BurstSpacing;
+        private int roundBurst;
+        private float burstSpacing;
+        private float burstInterval;
         float accuracyTolerance;
 
         //list of valid launcher modules with ammo
-        private List<ModulePartFirework> FireworkLaunchers;
+        private List<ModulePartFirework> fireworkLaunchers;
 
         ModuleWeaponController controller;
 
@@ -36,48 +37,48 @@ namespace KerbalCombatSystems
             UpdateSettings();
 
             // initialise debug line renderer
-            AimLine = KCSDebug.CreateLine(new Color(196f / 255f, 208f / 255f, 164f / 255f, 1f));
+            aimLine = KCSDebug.CreateLine(new Color(196f / 255f, 208f / 255f, 164f / 255f, 1f));
 
             //get list of fireworks
             FindFireworks(part.parent);
 
-            if (FireworkLaunchers.Count < 1)
+            if (fireworkLaunchers.Count < 1)
                 part.RemoveModule(part.GetComponent<ModuleFirework>());
             else
-                controller.aimPart = FireworkLaunchers.First().part;
+                controller.aimPart = fireworkLaunchers.First().part;
         }
 
         public override Vector3 Aim()
         {
             //if there is a ship target run the appropriate aiming angle calculations
-            if (Target != null)
+            if (target != null)
             {
-                if (FireworkLaunchers.Count < 1)
+                if (fireworkLaunchers.Count < 1)
                 {
                     controller.canFire = false;
                     return Vector3.zero;
                 }
 
                 //get the firework launcher to aim with and where it is currently facing
-                ModulePartFirework firstLauncher = FireworkLaunchers.First();
+                ModulePartFirework firstLauncher = fireworkLaunchers.First();
 
-                FiringPart = firstLauncher.part;
-                controller.aimPart = FiringPart;
-                aimVector = FiringPart.transform.up;
-                LeadVector = TargetLead(Target, FiringPart, fireworkSpeed).normalized;
+                firingPart = firstLauncher.part;
+                controller.aimPart = firingPart;
+                aimVector = firingPart.transform.up;
+                leadVector = TargetLead(target, firingPart, fireworkSpeed).normalized;
 
                 // Update debug lines.
-                Origin = FiringPart.transform.position;
-                KCSDebug.PlotLine(new[] { Origin, Origin + (aimVector * 15) }, AimLine);
+                origin = firingPart.transform.position;
+                KCSDebug.PlotLine(new[] { origin, origin + (aimVector * 15) }, aimLine);
             }
 
             //once aligned correctly start the firing sequence
-            if (!firing && OnTarget(LeadVector, aimVector, Target.CoM - FiringPart.transform.position, controller.targetSize, accuracyTolerance))
+            if (!firing && OnTarget(leadVector, aimVector, target.CoM - firingPart.transform.position, controller.targetSize, accuracyTolerance))
             {
                 Fire();
             }
 
-            return LeadVector;
+            return leadVector;
         }
 
         public override void Fire()
@@ -89,18 +90,18 @@ namespace KerbalCombatSystems
 
         private IEnumerator FireShells()
         {
-            int TempBurst = RoundBurst;
+            int tempBurst = roundBurst;
             //fire amount of shells
-            for (int i = 0; i < TempBurst; i++)
+            for (int i = 0; i < tempBurst; i++)
             {
-                if (FireworkLaunchers.Count < 1)
+                if (fireworkLaunchers.Count < 1)
                 {
                     controller.canFire = false;
                     break;
                 }
 
-                yield return new WaitForSeconds(BurstSpacing);
-                ModulePartFirework Launcher = FireworkLaunchers.Last();
+                yield return new WaitForSeconds(burstSpacing);
+                ModulePartFirework Launcher = fireworkLaunchers.Last();
 
                 // Change firework settings.
                 Launcher.variationOnShellDirection = false;
@@ -121,11 +122,13 @@ namespace KerbalCombatSystems
                 //clear expended launchers from the list
                 if (Launcher.fireworkShots < 1)
                 {
-                    FireworkLaunchers.Remove(Launcher);
+                    fireworkLaunchers.Remove(Launcher);
                     //add one more round to the burst to substitute missing shot
-                    TempBurst++;
+                    tempBurst++;
                 }
             }
+
+            yield return new WaitForSeconds(burstInterval);
 
             firing = false;
         }
@@ -135,29 +138,30 @@ namespace KerbalCombatSystems
             List<Part> childParts = part.parent.FindChildParts<Part>(true).ToList();
             childParts.Add(part.parent);
 
-            FireworkLaunchers = new List<ModulePartFirework>();
-            ModulePartFirework Firework;
+            fireworkLaunchers = new List<ModulePartFirework>();
+            ModulePartFirework firework;
 
             foreach (Part CurrentPart in childParts)
             {
-                Firework = CurrentPart.GetComponent<ModulePartFirework>();
-                if (Firework == null) continue;
+                firework = CurrentPart.GetComponent<ModulePartFirework>();
+                if (firework == null) continue;
 
-                FireworkLaunchers.Add(Firework);
+                fireworkLaunchers.Add(firework);
             }
         }
 
         public void OnDestroy()
         {
-            KCSDebug.DestroyLine(AimLine);
+            KCSDebug.DestroyLine(aimLine);
         }
 
         public override void UpdateSettings()
         {
             controller = part.FindModuleImplementing<ModuleWeaponController>();
-            Target = controller.target;
-            RoundBurst = (int)controller.FWRoundBurst;
-            BurstSpacing = controller.FWBurstSpacing;
+            target = controller.target;
+            roundBurst = (int)controller.FWRoundBurst;
+            burstSpacing = controller.FWBurstSpacing;
+            burstInterval = controller.FWBurstInterval;
             accuracyTolerance = controller.accuracyTolerance;
         }
     }

--- a/Source/KerbalCombatSystems/FlightController.cs
+++ b/Source/KerbalCombatSystems/FlightController.cs
@@ -15,7 +15,7 @@ namespace KerbalCombatSystems
         private bool facingDesiredRotation;
         public float throttle;
         public float throttleActual;
-        private float throttleLerped;
+        internal float throttleLerped;
         public float throttleLerpRate = 1;
         public float alignmentToleranceforBurn = 5;
 
@@ -39,6 +39,7 @@ namespace KerbalCombatSystems
             currentVectorLine = KCSDebug.CreateLine(Color.yellow);
             targetVectorLine = KCSDebug.CreateLine(Color.red);
             rcsLine = KCSDebug.CreateLine(Color.white);
+
             //rright = KCSDebug.CreateLine(Color.red);
             //rup = KCSDebug.CreateLine(Color.green);
             //rforward = KCSDebug.CreateLine(Color.blue);
@@ -49,6 +50,7 @@ namespace KerbalCombatSystems
             KCSDebug.DestroyLine(currentVectorLine);
             KCSDebug.DestroyLine(targetVectorLine);
             KCSDebug.DestroyLine(rcsLine);
+
             //KCSDebug.DestroyLine(rup);
             //KCSDebug.DestroyLine(rright);
             //KCSDebug.DestroyLine(rforward);
@@ -94,6 +96,7 @@ namespace KerbalCombatSystems
                 RCSVectorLerped = RCSVector;
 
             // This system works for now but it's convuluted and isn't very stable.
+            // todo: redo all of this.
             RCSVectorLerped = Vector3.Lerp(RCSVectorLerped, RCSVector, 5f * Time.fixedDeltaTime * Mathf.Clamp01(RCSVectorLerped.magnitude / RCSPower));
             RCSThrottle = Mathf.Lerp(0, 1.732f, Mathf.InverseLerp(0, RCSPower, RCSVectorLerped.magnitude));
             RCSThrust = RCSVectorLerped.normalized * RCSThrottle;
@@ -108,8 +111,8 @@ namespace KerbalCombatSystems
 
             //Vector3 origin = v.ReferenceTransform.position;
             //KCSDebug.PlotLine(new[] { origin, origin + right * 10 * v.ctrlState.X }, rright);
-            //KCSDebug.PlotLine(new[] { origin, origin + up * 10 *  v.ctrlState.Y}, rup);
-            //KCSDebug.PlotLine(new[] { origin, origin + forward * 10 * v.ctrlState.Z}, rforward);
+            //KCSDebug.PlotLine(new[] { origin, origin + up * 10 * v.ctrlState.Y }, rup);
+            //KCSDebug.PlotLine(new[] { origin, origin + forward * 10 * v.ctrlState.Z }, rforward);
 
             Vector3 origin = v.ReferenceTransform.position;
             KCSDebug.PlotLine(new[] { origin, origin + RCSThrust.normalized * Mathf.Clamp(RCSThrust.magnitude, 0, 15) }, rcsLine);

--- a/Source/KerbalCombatSystems/MainController.cs
+++ b/Source/KerbalCombatSystems/MainController.cs
@@ -487,6 +487,10 @@ namespace KerbalCombatSystems
                 Overlay.UpdateOpacity();
             }
 
+            // Hidden until CC supports fireworks.
+            //GUILayout.Label("Gameplay", titleStyle);
+            //SliderSetting(ref ModuleFirework.fireworkSpeed, "Firework Speed", 100, 500);
+
             GUILayout.EndScrollView();
             GUILayout.EndVertical();
 
@@ -504,7 +508,7 @@ namespace KerbalCombatSystems
 
             GUILayout.Label(setting.ToString(), centeredText, GUILayout.Width(windowWidth * 0.25f));
 
-            if (setting != settingLast)
+            if (setting != settingLast && text.Contains("opacity"))
                 updateOverlayOpacity = true;
 
             GUILayout.EndHorizontal();

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -191,20 +191,14 @@ namespace KerbalCombatSystems
             {
                 fc.RCSVector = vessel.ReferenceTransform.up;
 
-                // wait to try to prevent destruction of decoupler.
-                // todo: could increase heat tolerance temporarily or calculate a lower throttle.
                 yield return new WaitForSeconds(igniteDelay);
 
                 if (!isInterceptor)
                 {
-                    // pulse to 5 m/s.
-                    float burnTime = 0.5f;
-                    float driftVelocity = 5;
-
-                    fc.throttle = driftVelocity / burnTime / GetMaxAcceleration(vessel);
+                    fc.throttle = controller.pulseThrottle;
                     fc.Drive();
 
-                    yield return new WaitForSeconds(burnTime);
+                    yield return new WaitForSeconds(controller.pulseDuration);
 
                     fc.throttle = 0;
                 }

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -53,11 +53,13 @@ namespace KerbalCombatSystems
 
         private IEnumerator Launch()
         {
+            // 1. Separate from firer.
+
             // find decoupler
             seperator = FindDecoupler(part, "Default", false);
 
-            bool frontLaunch = Vector3.Dot(seperator.transform.up, vessel.ReferenceTransform.up) > 0.99;
-            controller.frontLaunch = frontLaunch;
+            // Store the direction the ship is facing.
+            Vector3 firerUp = vessel.ReferenceTransform.up;
 
             // todo:
             // electric charge check
@@ -78,6 +80,14 @@ namespace KerbalCombatSystems
                 Debug.Log("[KCS]: Couldn't find decoupler.");
             }
 
+            // todo: use firevector instead.
+            // We are launching in the direction of the ship's propulsion, we need to flag this so the ship can throttle down temporarily.
+            bool frontLaunch = Vector3.Angle(vessel.ReferenceTransform.up, firerUp) < 50;
+            controller.frontLaunch = frontLaunch;
+
+
+            // 2. Initial setup.
+
             // turn on engines
             engines = vessel.FindPartModulesImplementing<ModuleEngines>();
             engines.ForEach(e => e.Activate());
@@ -89,7 +99,6 @@ namespace KerbalCombatSystems
             fc.alignmentToleranceforBurn = isInterceptor ? 60 : 20;
             fc.lerpAttitude = false;
             fc.throttleLerpRate = 99;
-            fc.RCSVector = vessel.ReferenceTransform.up;
             fc.RCSPower = 20;
             fc.Drive();
 
@@ -118,33 +127,113 @@ namespace KerbalCombatSystems
 
             vessel.targetObject = target;
 
-            // wait to try to prevent destruction of decoupler.
-            // todo: could increase heat tolerance temporarily or calculate a lower throttle.
-            yield return new WaitForSeconds(igniteDelay);
 
-            if (!isInterceptor)
+            // 3. Start moving away from firer.
+
+            // Check if it's a horizontal launch.
+
+            Ray launchRay = new Ray(vessel.ReferenceTransform.position, vessel.ReferenceTransform.up);
+            bool horizontalLaunch = RayIntersectsVessel(firer, launchRay);
+
+            if (horizontalLaunch)
             {
-                // pulse to 5 m/s.
-                float burnTime = 0.5f;
-                float driftVelocity = 5;
+                Vector3 horizontal = firer.ReferenceTransform.forward;
+                bool foundExit = false;
 
-                fc.throttle = driftVelocity / burnTime / GetMaxAcceleration(vessel);
+                // First check directions at 90 degrees to the firer's roll direction.
+                for (int i = 0; i < 4; i++)
+                {
+                    //horizontal = Vector3.Cross(horizontal, vessel.ReferenceTransform.up);
+                    horizontal = Quaternion.AngleAxis(360 * i / 4, vessel.ReferenceTransform.up) * firer.ReferenceTransform.forward;
+                    launchRay.direction = horizontal;
+
+                    foundExit = !RayIntersectsVessel(firer, launchRay);
+
+                    if (foundExit)
+                        break;
+                }
+
+                // If we still can't find an exit, check diagonally.
+                // We do this second to prioritise straight exits from large openings.
+                if (!foundExit)
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        horizontal = Quaternion.AngleAxis(360 * i / 4 + 45, vessel.ReferenceTransform.up) * firer.ReferenceTransform.forward;
+                        launchRay.direction = horizontal;
+
+                        foundExit = !RayIntersectsVessel(firer, launchRay);
+
+                        if (foundExit)
+                            break;
+                    }
+                }
+
+                fc.RCSVector = horizontal.normalized * 200000f;
                 fc.Drive();
+                float checkInterval = 0.1f;
+                float lastChecked = 0;
 
-                yield return new WaitForSeconds(burnTime);
+                while (horizontalLaunch)
+                {
+                    //yield return new WaitForSeconds(0.1f);
+                    yield return new WaitForFixedUpdate();
 
-                fc.throttle = 0;
+                    fc.RCSVector = horizontal.normalized * 200000f;
+                    fc.Drive();
+
+                    if (Time.time - lastChecked > checkInterval)
+                    {
+                        lastChecked = Time.time;
+
+                        launchRay.origin = vessel.ReferenceTransform.position;
+                        launchRay.direction = vessel.ReferenceTransform.up;
+                        //horizontalLaunch = RayIntersectsVessel(firer, launchRay);
+                        horizontalLaunch = CylinderIntersectsVessel(firer, launchRay, 1.5f);
+                    }
+                }
+
+                yield return new WaitForSeconds(igniteDelay);
             }
             else
             {
-                fc.throttle = 1;
+                fc.RCSVector = vessel.ReferenceTransform.up;
+
+                // wait to try to prevent destruction of decoupler.
+                // todo: could increase heat tolerance temporarily or calculate a lower throttle.
+                yield return new WaitForSeconds(igniteDelay);
+
+                if (!isInterceptor)
+                {
+                    // pulse to 5 m/s.
+                    float burnTime = 0.5f;
+                    float driftVelocity = 5;
+
+                    fc.throttle = driftVelocity / burnTime / GetMaxAcceleration(vessel);
+                    fc.Drive();
+
+                    yield return new WaitForSeconds(burnTime);
+
+                    fc.throttle = 0;
+                }
+                else
+                {
+                    fc.throttle = 1;
+                }
+
+                fc.RCSVector = Vector3.zero;
+                fc.Drive();
             }
-            fc.RCSVector = Vector3.zero;
-            fc.Drive();
+
+
+            // 4. Get line of sight to the target.
 
             Ray targetRay = new Ray();
+            targetRay.origin = vessel.ReferenceTransform.position;
+            targetRay.direction = target.transform.position - vessel.transform.position;
+            bool lineOfSight = !RayIntersectsVessel(firer, targetRay);
+
             Vector3 sideways;
-            bool lineOfSight = false;
             bool clear = false;
             float previousTolerance = fc.alignmentToleranceforBurn;
 
@@ -161,14 +250,18 @@ namespace KerbalCombatSystems
                     // We don't have line of sight with the target yet, but are we clear of the ship?
 
                     sideways = vessel.transform.forward;
+                    int blockedCount = 0;
 
                     for (int i = 0; i < 4; i++)
                     {
                         targetRay.origin = vessel.ReferenceTransform.position;
                         sideways = Vector3.Cross(sideways, vessel.ReferenceTransform.up);
                         targetRay.direction = sideways;
-                        clear = !RayIntersectsVessel(firer, targetRay);
 
+                        if (RayIntersectsVessel(firer, targetRay))
+                            blockedCount++;
+
+                        clear = blockedCount < 2;
                         if (!clear) break;
                     }
                 }
@@ -199,6 +292,9 @@ namespace KerbalCombatSystems
             }
 
             fc.alignmentToleranceforBurn = previousTolerance;
+
+
+            // 5. Finish setting up the missile.
 
             // Remove end cap. todo: will need to change to support cluster missiles.
             List<ModuleDecouple> decouplers = vessel.FindPartModulesImplementing<ModuleDecouple>();

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -139,17 +139,15 @@ namespace KerbalCombatSystems
             {
                 Vector3 horizontal = firer.ReferenceTransform.forward;
                 bool foundExit = false;
+                Vector3 start = Vector3.ProjectOnPlane(firer.ReferenceTransform.forward, vessel.ReferenceTransform.up);
 
                 // First check directions at 90 degrees to the firer's roll direction.
                 for (int i = 0; i < 4; i++)
                 {
-                    //horizontal = Vector3.Cross(horizontal, vessel.ReferenceTransform.up);
-                    horizontal = Quaternion.AngleAxis(360 * i / 4, vessel.ReferenceTransform.up) * firer.ReferenceTransform.forward;
+                    horizontal = Quaternion.AngleAxis(360f * (i / 4f), vessel.ReferenceTransform.up) * start;
                     launchRay.direction = horizontal;
 
-                    foundExit = !RayIntersectsVessel(firer, launchRay);
-
-                    if (foundExit)
+                    if (foundExit = !RayIntersectsVessel(firer, launchRay))
                         break;
                 }
 
@@ -162,24 +160,19 @@ namespace KerbalCombatSystems
                         horizontal = Quaternion.AngleAxis(360 * i / 4 + 45, vessel.ReferenceTransform.up) * firer.ReferenceTransform.forward;
                         launchRay.direction = horizontal;
 
-                        foundExit = !RayIntersectsVessel(firer, launchRay);
-
-                        if (foundExit)
+                        if (!RayIntersectsVessel(firer, launchRay))
                             break;
                     }
                 }
 
-                fc.RCSVector = horizontal.normalized * 200000f;
-                fc.Drive();
+                fc.RCSVector = horizontal.normalized * 200000f; // idk
                 float checkInterval = 0.1f;
                 float lastChecked = 0;
 
                 while (horizontalLaunch)
                 {
-                    //yield return new WaitForSeconds(0.1f);
                     yield return new WaitForFixedUpdate();
 
-                    fc.RCSVector = horizontal.normalized * 200000f;
                     fc.Drive();
 
                     if (Time.time - lastChecked > checkInterval)
@@ -188,8 +181,7 @@ namespace KerbalCombatSystems
 
                         launchRay.origin = vessel.ReferenceTransform.position;
                         launchRay.direction = vessel.ReferenceTransform.up;
-                        //horizontalLaunch = RayIntersectsVessel(firer, launchRay);
-                        horizontalLaunch = CylinderIntersectsVessel(firer, launchRay, 1.5f);
+                        horizontalLaunch = CylinderIntersectsVessel(firer, launchRay, 1.25f / 2);
                     }
                 }
 

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -79,7 +79,6 @@ namespace KerbalCombatSystems
             {
                 Debug.Log("[KCS]: Couldn't find decoupler.");
             }
-            
             // Wait for seperation to take effect
             yield return new WaitForEndOfFrame();
 

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -14,6 +14,7 @@ namespace KerbalCombatSystems
         private float maxThrust;
         private Vessel target;
         private Vessel firer;
+        private float igniteDelay;
         private float terminalVelocity;
         private ModuleWeaponController targetWeapon;
         private bool isInterceptor;
@@ -119,7 +120,7 @@ namespace KerbalCombatSystems
 
             // wait to try to prevent destruction of decoupler.
             // todo: could increase heat tolerance temporarily or calculate a lower throttle.
-            yield return new WaitForSeconds(0.2f);
+            yield return new WaitForSeconds(igniteDelay);
 
             if (!isInterceptor)
             {
@@ -330,6 +331,7 @@ namespace KerbalCombatSystems
             isInterceptor = controller.isInterceptor;
             targetWeapon = controller.targetWeapon;
             firer = vessel;
+            igniteDelay = controller.igniteDelay;
         }
 
         public override void Fire()

--- a/Source/KerbalCombatSystems/ObjectTracking.cs
+++ b/Source/KerbalCombatSystems/ObjectTracking.cs
@@ -10,14 +10,14 @@ namespace KerbalCombatSystems
     class ModuleObjectTracking : PartModule
     {
         //all ore scanning parts plus the sentinal at superlong range
-        const string objectTrackingGroupName = "Situational Awareness";
+        const string objectTrackingGroupName = "Object Tracking";
         private int scalingFactor;
 
         [KSPField(
               guiActive = true,
               guiActiveEditor = true,
-              guiName = "Detection Range",
-              guiUnits = "m",
+              guiName = "Lock Range",
+              guiUnits = " m",
               groupName = objectTrackingGroupName,
               groupDisplayName = objectTrackingGroupName),
               UI_Label(scene = UI_Scene.All)]
@@ -26,12 +26,28 @@ namespace KerbalCombatSystems
         [KSPField(isPersistant = true)]
         public float baseDetectionRange = 0f;
 
+        [KSPField(isPersistant = true,
+            guiActive = true,
+            guiActiveEditor = true,
+            guiName = "Deploy Automatically",
+            groupName = objectTrackingGroupName,
+            groupDisplayName = objectTrackingGroupName),
+            UI_Toggle(
+                enabledText = "Enabled",
+                disabledText = "Disabled",
+                scene = UI_Scene.All
+            )]
+        public bool animate = true;
+
         public override string GetInfo()
         {
             StringBuilder output = new StringBuilder();
 
+            // GetInfo runs once at game start when CurrentGame is null so we need to use the default value.
+            float scalingFactor = 5f;
+
             output.Append(Environment.NewLine);
-            output.Append(String.Format("Detection Range: {0} m", detectionRange));
+            output.Append(string.Format("Detection Range: {0} m", baseDetectionRange * scalingFactor));
 
             return output.ToString();
         }

--- a/Source/KerbalCombatSystems/ObjectTracking.cs
+++ b/Source/KerbalCombatSystems/ObjectTracking.cs
@@ -56,6 +56,13 @@ namespace KerbalCombatSystems
         {
             scalingFactor = HighLogic.CurrentGame.Parameters.CustomParams<KCSCombat>().scalingFactor;
             detectionRange = baseDetectionRange * scalingFactor;
+
+            // Hide the animation option for the ship controller.
+            if (part.partInfo.category == PartCategories.Control)
+            {
+                Fields["animate"].guiActiveEditor = false;
+                Fields["animate"].guiActive = false;
+            }
         }
     }
 }

--- a/Source/KerbalCombatSystems/Overlay.cs
+++ b/Source/KerbalCombatSystems/Overlay.cs
@@ -26,7 +26,7 @@ namespace KerbalCombatSystems
         public static float markerOpacity = 0.3f;
         public static float rangeNumberOpacity = 0.2f;
         public static float shipnameOpacity = 0.6f;
-        public static float globalOpacity = 1.2f;
+        public static float globalOpacity = 1.6f;
 
         public static float markerScale = 10;
         public static float iconSize = 25;
@@ -273,8 +273,6 @@ namespace KerbalCombatSystems
                 centre.up = FlightGlobals.ActiveVessel.ReferenceTransform.forward;
             else
                 centre.up = mainCamera.getReferenceFrame() * Vector3.up;
-
-            centre.position = activeVessel.CoM;
         }
 
         private void Update()
@@ -307,6 +305,7 @@ namespace KerbalCombatSystems
             if (hideOverlay)
                 return;
 
+            centre.position = activeVessel.CoM;
             WatchShipList();
 
             // Show the overlay lines only when the camera is zoomed out.
@@ -706,7 +705,7 @@ namespace KerbalCombatSystems
 
         private void OnGUI()
         {
-            if (MapView.MapIsEnabled || PauseMenu.isOpen || hideOverlay)
+            if (MapView.MapIsEnabled || PauseMenu.isOpen || hideOverlay || Camera.main == null)
                 return;
 
             if (Event.current.type.Equals(EventType.Repaint))
@@ -827,15 +826,18 @@ namespace KerbalCombatSystems
             {
                 shipNameStyle = new GUIStyle(GUI.skin.label);
 
-                Font calibriliFont = Resources.FindObjectsOfTypeAll<Font>().ToList().Find(f => f.name == "calibrili");
+                Font calibriliFont = Resources.FindObjectsOfTypeAll<Font>().ToList().Find(f => f.name == "calibril");
                 if (calibriliFont != null)
+                {
                     shipNameStyle.font = calibriliFont;
+                    shipNameStyle.fontStyle = FontStyle.Bold;
+                }
             }
 
             if (shipNameStyle.fontSize != shipFontSize)
                 shipNameStyle.fontSize = shipFontSize;
 
-            Vector2 textSize = shipNameStyle.CalcSize(new GUIContent("DD-02 PAS Rigel Kentaurus Class Battlecruiser"));
+            Vector2 textSize = shipNameStyle.CalcSize(new GUIContent("DD-02 PAS Rigel Kentaurus Class Battlecruiser")); // Max Name Length
             Rect textRect = new Rect(0, 0, textSize.x, textSize.y);
             Vector3 screenPos;
 
@@ -854,15 +856,18 @@ namespace KerbalCombatSystems
 
                 screenPos = Camera.main.WorldToScreenPoint(ship.vessel.CoM);
 
-                textRect.x = screenPos.x + 18;
-                textRect.y = (Screen.height - screenPos.y) - (textSize.y / 2);
-
+                textRect.x = screenPos.x + 18; // Shift right of centre.
+                textRect.y = (Screen.height - screenPos.y) - (textSize.y / 2); // Vertically align middle of text with centre.
+    
                 if (textRect.x > Screen.width || textRect.y > Screen.height || screenPos.z < 0) continue;
 
                 // Create a shorterned ship name with a bold prefix.
 
                 string name = ShortenName(ship.vessel.GetDisplayName());
-                string[] nameWords = name.Split(' ');
+
+                // Bold prefix disabled for now.
+                
+                /*string[] nameWords = name.Split(' ');
                 bool endPrefix = false;
                 bool allCaps;
 
@@ -877,13 +882,13 @@ namespace KerbalCombatSystems
                     nameWords[i] = allCaps && !endPrefix ? $"<b>{w}</b>" : $"<i>{w}</i>";
                 }
 
-                name = string.Join(" ", nameWords);
+                name = string.Join(" ", nameWords);*/
 
                 // Draw the ship name.
 
                 shipNameColour.a = shipnameOpacity * alpha * globalOpacity;
                 GUI.color = shipNameColour;
-                GUI.Label(textRect, name, shipNameStyle);
+                GUI.Label(textRect, "  " + name, shipNameStyle);
             }
         }
 

--- a/Source/KerbalCombatSystems/RocketTargeting.cs
+++ b/Source/KerbalCombatSystems/RocketTargeting.cs
@@ -115,7 +115,7 @@ namespace KerbalCombatSystems
                     // Create a static pink ball where the hit is predicted to happen.
                     if (KCSDebug.showLines)
                     {
-                        GameObject prediction = CreateSphere();
+                        GameObject prediction = CreateSphere(timeToHit + 5);
                         prediction.transform.position = origin + leadVector;
                     }
                 }
@@ -281,10 +281,13 @@ namespace KerbalCombatSystems
             controller.aimPart = decoupler.part;
         }
 
-        public void OnDestroy() =>
+        public void OnDestroy()
+        {
             KCSDebug.DestroyLine(leadLine);
+            Destroy(prediction);
+        }
 
-        private GameObject CreateSphere()
+        private GameObject CreateSphere(float deleteAfter = 0)
         {
             GameObject prediction = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             var mr = prediction.GetComponent<MeshRenderer>();
@@ -294,9 +297,11 @@ namespace KerbalCombatSystems
 
             mr.material = sphereMat;
 
-            //todo sphere doesn't destroy
             prediction.transform.localScale = prediction.transform.localScale * 2;
             Destroy(prediction.GetComponent<SphereCollider>());
+
+            if (deleteAfter > 0)
+                Destroy(prediction, deleteAfter);
 
             return prediction;
         }

--- a/Source/KerbalCombatSystems/Settings.cs
+++ b/Source/KerbalCombatSystems/Settings.cs
@@ -61,7 +61,8 @@ namespace KerbalCombatSystems
         }
     }
 
-    public class KCSOpponents : GameParameters.CustomParameterNode
+    // Hidden until implementation.
+    /*public class KCSOpponents : GameParameters.CustomParameterNode
     {
         public override string Title { get { return "Opponent Spawning"; } }
         public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.ANY; } }
@@ -91,5 +92,5 @@ namespace KerbalCombatSystems
         {
             return null;
         }
-    }
+    }*/
 }

--- a/Source/KerbalCombatSystems/ShipController.cs
+++ b/Source/KerbalCombatSystems/ShipController.cs
@@ -212,6 +212,9 @@ namespace KerbalCombatSystems
 
             if (behaviourCoroutine != null)
                 StopCoroutine(behaviourCoroutine);
+
+            vessel.ActionGroups.SetGroup(KSPActionGroup.SAS, true);
+            vessel.Autopilot.SetMode(VesselAutopilot.AutopilotMode.StabilityAssist);
         }
 
         private void Start()

--- a/Source/KerbalCombatSystems/ShipController.cs
+++ b/Source/KerbalCombatSystems/ShipController.cs
@@ -29,7 +29,7 @@ namespace KerbalCombatSystems
 
         // Ship AI variables.
 
-        private KCSFlightController fc;
+        internal KCSFlightController fc;
 
         public Vessel target;
         private ModuleShipController targetController;
@@ -636,6 +636,9 @@ namespace KerbalCombatSystems
                 lastFired = Time.time;
                 bool checkWeapons = false;
                 float targetMass = (float)target.totalMass;
+
+                // Decide how many missiles to use based on the mass of the missile we want to use, the mass of the target,
+                // and the mass of the weapons already on their way to the target.
 
                 if (targetController.incomingWeapons.Count > 0)
                 {

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -300,23 +300,27 @@ namespace KerbalCombatSystems
             return (v1.transform.position - v2.transform.position).magnitude;
         }
 
-        public static bool RayIntersectsVessel(Vessel v, Ray r)
+        public static bool RayIntersectsVessel(Vessel v, Ray r, Color color = default)
         {
+            RaycastHit hitInfo;
+
             foreach (Part p in v.parts)
             {
-                foreach (Bounds b in p.GetColliderBounds())
+                foreach (Collider c in p.GetPartColliders())
                 {
-                    if (b.IntersectRay(r)) return true;
+                    if (c.Raycast(r, out hitInfo, 50f))
+                        return true;
                 }
             }
 
             return false;
         }
 
-        public static bool CylinderIntersectsVessel(Vessel v, Ray r, float diameter, int sides = 4)
+        public static bool CylinderIntersectsVessel(Vessel v, Ray r, float radius, int sides = 4)
         {
             Ray edgeRay = new Ray(r.origin, r.direction);
-            Vector3 cylinderEdge = Vector3.ProjectOnPlane(Vector3.up, r.direction).normalized * diameter;
+            Vector3 cylinderEdge = Vector3.ProjectOnPlane(Vector3.up, r.direction).normalized * radius;
+            RaycastHit hitInfo;
 
             for (int i = 0; i < sides; i++)
             {
@@ -324,9 +328,10 @@ namespace KerbalCombatSystems
                 
                 foreach (Part p in v.parts)
                 {
-                    foreach (Bounds b in p.GetColliderBounds())
+                    foreach (Collider c in p.GetPartColliders())
                     {
-                        if (b.IntersectRay(edgeRay)) return true;
+                        if (c.Raycast(edgeRay, out hitInfo, 50f))
+                            return true;
                     }
                 }
             }

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -312,6 +312,27 @@ namespace KerbalCombatSystems
 
             return false;
         }
+
+        public static bool CylinderIntersectsVessel(Vessel v, Ray r, float diameter, int sides = 4)
+        {
+            Ray edgeRay = new Ray(r.origin, r.direction);
+            Vector3 cylinderEdge = Vector3.ProjectOnPlane(Vector3.up, r.direction).normalized * diameter;
+
+            for (int i = 0; i < sides; i++)
+            {
+                edgeRay.origin = r.origin + (Quaternion.AngleAxis(360f * (i / (float)sides), r.direction) * cylinderEdge);
+                
+                foreach (Part p in v.parts)
+                {
+                    foreach (Bounds b in p.GetColliderBounds())
+                    {
+                        if (b.IntersectRay(edgeRay)) return true;
+                    }
+                }
+            }
+
+            return false;
+        }
         #endregion
     }
 

--- a/Source/KerbalCombatSystems/WeaponController.cs
+++ b/Source/KerbalCombatSystems/WeaponController.cs
@@ -82,8 +82,8 @@ namespace KerbalCombatSystems
         [KSPField(isPersistant = true,
               guiActive = true,
               guiActiveEditor = true,
-              guiName = "Terminal Velocity",
-              guiUnits = "m/s",
+              guiName = "Speed Limit",
+              guiUnits = " m/s",
               groupName = missileGroupName,
               groupDisplayName = missileGroupName),
               UI_FloatRange(
@@ -93,6 +93,21 @@ namespace KerbalCombatSystems
                   scene = UI_Scene.All
               )]
         public float terminalVelocity = 2000f;
+
+        [KSPField(isPersistant = true,
+              guiActive = true,
+              guiActiveEditor = true,
+              guiName = "Ignition Delay",
+              guiUnits = " s",
+              groupName = missileGroupName,
+              groupDisplayName = missileGroupName),
+              UI_FloatRange(
+                  minValue = 0f,
+                  maxValue = 1f,
+                  stepIncrement = 0.01f,
+                  scene = UI_Scene.All
+              )]
+        public float igniteDelay = 0.2f;
 
         [KSPField(isPersistant = true,
             guiActive = true,
@@ -202,6 +217,22 @@ namespace KerbalCombatSystems
         public float FWBurstSpacing = 0.25f;
 
         [KSPField(isPersistant = true,
+              guiActive = true,
+              guiActiveEditor = true,
+              guiName = "Aim Tolerance",
+              guiUnits = " Target Rad.",
+              groupName = FireworkGroupName,
+              groupDisplayName = FireworkGroupName),
+              UI_FloatRange(
+                  minValue = 0.1f,
+                  maxValue = 2f,
+                  stepIncrement = 0.1f,
+                  scene = UI_Scene.All
+              )]
+        public float FWaccuracyTolerance = 1f;
+
+        // Hidden until implementation.
+        /*[KSPField(isPersistant = true,
             guiActive = true,
             guiActiveEditor = true,
             guiName = "Use for Flak",
@@ -212,7 +243,7 @@ namespace KerbalCombatSystems
                 disabledText = "Disabled",
                 scene = UI_Scene.All
             )]
-        public bool FWUseAsCIWS = false;
+        public bool FWUseAsCIWS = false;*/
 
         #endregion
 
@@ -251,14 +282,14 @@ namespace KerbalCombatSystems
         [KSPField(isPersistant = true,
               guiActive = true,
               guiActiveEditor = true,
-              guiName = "Aiming Tolerance",
-              guiUnits = " Target Radius",
+              guiName = "Aim Tolerance",
+              guiUnits = " Target Rad.",
               groupName = rocketGroupName,
               groupDisplayName = rocketGroupName),
               UI_FloatRange(
                   minValue = 0.1f,
                   maxValue = 2f,
-                  stepIncrement = 0.01f,
+                  stepIncrement = 0.1f,
                   scene = UI_Scene.All
               )]
         public float accuracyTolerance = 0.5f;
@@ -384,14 +415,18 @@ namespace KerbalCombatSystems
             Fields["terminalVelocity"].guiActiveEditor = weaponType == "Missile";
             Fields["useAsInterceptor"].guiActive = weaponType == "Missile";
             Fields["useAsInterceptor"].guiActiveEditor = weaponType == "Missile";
+            Fields["igniteDelay"].guiActive = weaponType == "Missile";
+            Fields["igniteDelay"].guiActiveEditor = weaponType == "Missile";
 
             // Firework fields.
             Fields["FWRoundBurst"].guiActive = weaponType == "Firework";
             Fields["FWRoundBurst"].guiActiveEditor = weaponType == "Firework";
             Fields["FWBurstSpacing"].guiActive = weaponType == "Firework";
             Fields["FWBurstSpacing"].guiActiveEditor = weaponType == "Firework";
-            Fields["FWUseAsCIWS"].guiActive = weaponType == "Firework";
-            Fields["FWUseAsCIWS"].guiActiveEditor = weaponType == "Firework";
+            //Fields["FWUseAsCIWS"].guiActive = weaponType == "Firework";
+            //Fields["FWUseAsCIWS"].guiActiveEditor = weaponType == "Firework";
+            Fields["FWaccuracyTolerance"].guiActive = weaponType == "Firework";
+            Fields["FWaccuracyTolerance"].guiActiveEditor = weaponType == "Firework";
             
             // Rocket fields.
             Fields["firingInterval"].guiActive = weaponType == "Rocket";
@@ -496,7 +531,7 @@ namespace KerbalCombatSystems
                 parent = part.parent;
 
             var parts = parent.FindChildParts<Part>(true).ToList();
-            childDecouplers = parts.FindAll(p => p.HasModuleImplementing<ModuleDecouple>()).Count;
+            childDecouplers = parts.FindAll(p => p.HasModuleImplementing<ModuleDecouple>()).Count; // todo: add ModuleAnchoredDecoupler 
         }
 
         public float CalculateAcceleration(Part decoupler = null)
@@ -565,6 +600,11 @@ namespace KerbalCombatSystems
             return typeModule.Aim();
         }
 
+        public void UpdateSettings()
+        {
+            typeModule.UpdateSettings();
+        }
+
         // 'Fire' button.
 
         [KSPEvent(guiActive = true,
@@ -591,5 +631,7 @@ namespace KerbalCombatSystems
         }
 
         virtual public void Setup() { }
+
+        virtual public void UpdateSettings() { }
     }
 }

--- a/Source/KerbalCombatSystems/WeaponController.cs
+++ b/Source/KerbalCombatSystems/WeaponController.cs
@@ -63,7 +63,7 @@ namespace KerbalCombatSystems
         [KSPField(isPersistant = true,
                guiActive = true,
                guiActiveEditor = true,
-               guiName = "Target Mass Ratio",
+               guiName = "Mass Ratio",
                guiUnits = "x",
                groupName = weaponGroupName,
                groupDisplayName = weaponGroupName),

--- a/Source/KerbalCombatSystems/WeaponController.cs
+++ b/Source/KerbalCombatSystems/WeaponController.cs
@@ -249,7 +249,7 @@ namespace KerbalCombatSystems
               guiActive = true,
               guiActiveEditor = true,
               guiName = "Burst Round Spacing",
-              guiUnits = " Seconds",
+              guiUnits = " s",
               groupName = FireworkGroupName,
               groupDisplayName = FireworkGroupName),
               UI_FloatRange(
@@ -259,6 +259,21 @@ namespace KerbalCombatSystems
                   scene = UI_Scene.All
               )]
         public float FWBurstSpacing = 0.25f;
+
+        [KSPField(isPersistant = true,
+              guiActive = true,
+              guiActiveEditor = true,
+              guiName = "Burst Interval",
+              guiUnits = " s",
+              groupName = FireworkGroupName,
+              groupDisplayName = FireworkGroupName),
+              UI_FloatRange(
+                  minValue = 0f,
+                  maxValue = 5f,
+                  stepIncrement = 0.05f,
+                  scene = UI_Scene.All
+              )]
+        public float FWBurstInterval = 0.5f;
 
         [KSPField(isPersistant = true,
               guiActive = true,
@@ -461,6 +476,14 @@ namespace KerbalCombatSystems
             Fields["useAsInterceptor"].guiActiveEditor = weaponType == "Missile";
             Fields["igniteDelay"].guiActive = weaponType == "Missile";
             Fields["igniteDelay"].guiActiveEditor = weaponType == "Missile";
+            Fields["pulseThrottle"].guiActive = weaponType == "Missile";
+            Fields["pulseThrottle"].guiActiveEditor = weaponType == "Missile"; 
+            Fields["salvoSpacing"].guiActive = weaponType == "Missile";
+            Fields["salvoSpacing"].guiActiveEditor = weaponType == "Missile"; 
+            Fields["pulseDuration"].guiActive = weaponType == "Missile";
+            Fields["pulseDuration"].guiActiveEditor = weaponType == "Missile"; 
+            Fields["igniteDelay"].guiActive = weaponType == "Missile";
+            Fields["igniteDelay"].guiActiveEditor = weaponType == "Missile"; 
 
             // Firework fields.
             Fields["FWRoundBurst"].guiActive = weaponType == "Firework";
@@ -471,6 +494,8 @@ namespace KerbalCombatSystems
             //Fields["FWUseAsCIWS"].guiActiveEditor = weaponType == "Firework";
             Fields["FWaccuracyTolerance"].guiActive = weaponType == "Firework";
             Fields["FWaccuracyTolerance"].guiActiveEditor = weaponType == "Firework";
+            Fields["FWBurstInterval"].guiActive = weaponType == "Firework";
+            Fields["FWBurstInterval"].guiActiveEditor = weaponType == "Firework";
             
             // Rocket fields.
             Fields["firingInterval"].guiActive = weaponType == "Rocket";

--- a/Source/KerbalCombatSystems/WeaponController.cs
+++ b/Source/KerbalCombatSystems/WeaponController.cs
@@ -530,8 +530,7 @@ namespace KerbalCombatSystems
             else
                 parent = part.parent;
 
-            var parts = parent.FindChildParts<Part>(true).ToList();
-            childDecouplers = parts.FindAll(p => p.HasModuleImplementing<ModuleDecouple>()).Count; // todo: add ModuleAnchoredDecoupler 
+            childDecouplers = FindDecouplerChildren(parent, "Default", true).Count;
         }
 
         public float CalculateAcceleration(Part decoupler = null)

--- a/Source/KerbalCombatSystems/WeaponController.cs
+++ b/Source/KerbalCombatSystems/WeaponController.cs
@@ -97,8 +97,37 @@ namespace KerbalCombatSystems
         [KSPField(isPersistant = true,
               guiActive = true,
               guiActiveEditor = true,
-              guiName = "Ignition Delay",
+              guiName = "Launch Delay",
               guiUnits = " s",
+              groupName = missileGroupName,
+              groupDisplayName = missileGroupName),
+              UI_FloatRange(
+                  minValue = 0f,
+                  maxValue = 2f,
+                  stepIncrement = 0.1f,
+                  scene = UI_Scene.All
+              )]
+        public float igniteDelay = 0.2f;
+
+        [KSPField(isPersistant = true,
+              guiActive = true,
+              guiActiveEditor = true,
+              guiName = "Launch Duration",
+              guiUnits = " s",
+              groupName = missileGroupName,
+              groupDisplayName = missileGroupName),
+              UI_FloatRange(
+                  minValue = 0f,
+                  maxValue = 5f,
+                  stepIncrement = 0.1f,
+                  scene = UI_Scene.All
+              )]
+        public float pulseDuration = 0.5f;
+
+        [KSPField(isPersistant = true,
+              guiActive = true,
+              guiActiveEditor = true,
+              guiName = "Launch Throttle",
               groupName = missileGroupName,
               groupDisplayName = missileGroupName),
               UI_FloatRange(
@@ -107,7 +136,22 @@ namespace KerbalCombatSystems
                   stepIncrement = 0.01f,
                   scene = UI_Scene.All
               )]
-        public float igniteDelay = 0.2f;
+        public float pulseThrottle = 0.5f;
+
+        [KSPField(isPersistant = true,
+              guiActive = true,
+              guiActiveEditor = true,
+              guiName = "Salvo Spacing",
+              guiUnits = " s",
+              groupName = missileGroupName,
+              groupDisplayName = missileGroupName),
+              UI_FloatRange(
+                  minValue = 0.2f,
+                  maxValue = 5f,
+                  stepIncrement = 0.1f,
+                  scene = UI_Scene.All
+              )]
+        public float salvoSpacing = 0.8f;
 
         [KSPField(isPersistant = true,
             guiActive = true,


### PR DESCRIPTION
- Added automatic support for horizontal missile launches via RCS.
- Added a target prioritisation setting based on a mass range, only applies to targets within 2x max weapons range.
- Added a setting to toggle the automatic playing of animations on scanners.
- Added a 'Salvo Interval' setting to the ship controller for controlling the time between missile salvos.
- Added a setting to the ship controller to toggle evasion.
- Added a 'Forward Fire Throttle Limit' setting to the ship controller to limit the throttle while missiles are launching from the front of the ship. Zero by default.
- Added a setting for time between firework bursts.
- Added missile settings:
	- Launch delay.
	- Launch duration.
	- Launch throttle.
	- Salvo spacing.

- Changed accuracy threshold for fireworks from a fixed angle to a multiple of the target radius.
- Ships will no longer move away from their target when below minimum range if their current weapon is a projectile.
- Ships will now ignore target intercept adjustments of less than a second.
- Ships now decide whether to withdraw north or south based on the position of enemy ships.  
- RCS with throttle enabled now counts towards ship propulsion status.
- Renamed some settings for clarity.
- Hid unused settings.
- Changed the style of the ship labels in the overlay.

- Fixed a bug causing missile stacks to fire in the wrong order.
- Fixed object tracking info panels in part menu displaying 0.
- Fixed a ship movement bug caused by max weapon range exceeding lock range.
- Fixed a bug that was preventing the use of throttle hotkeys after turning off the AI.